### PR TITLE
Stop camera in preview when going to another screen

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -175,6 +175,6 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
-  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:4.2.0'
+  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:4.2.1'
   implementation 'com.twilio:audioswitch:1.1.7'
 }

--- a/android/src/main/java/com/reactnativemembrane/MembranePackage.kt
+++ b/android/src/main/java/com/reactnativemembrane/MembranePackage.kt
@@ -1,6 +1,5 @@
 package com.reactnativemembrane
 
-import VideoPreviewViewManager
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext

--- a/android/src/main/java/com/reactnativemembrane/VideoPreviewView.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoPreviewView.kt
@@ -1,3 +1,5 @@
+package com.reactnativemembrane
+
 import org.membraneframework.rtc.media.LocalVideoTrack
 import org.membraneframework.rtc.ui.VideoTextureViewRenderer
 import org.webrtc.PeerConnectionFactory
@@ -5,13 +7,31 @@ import android.content.Context
 import org.membraneframework.rtc.media.VideoParameters
 import org.webrtc.EglBase
 
-class VideoPreviewView(private val context: Context) {
-  var view: VideoTextureViewRenderer = VideoTextureViewRenderer(context)
+class VideoPreviewView(private val context: Context): VideoTextureViewRenderer(context) {
   private lateinit var localVideoTrack: LocalVideoTrack
   private lateinit var eglBase: EglBase
   private lateinit var peerConnectionFactory: PeerConnectionFactory
 
-  fun init() {
+  fun switchCamera(captureDeviceId: String) {
+    localVideoTrack.switchCamera(captureDeviceId)
+  }
+
+  private fun dispose() {
+    localVideoTrack.removeRenderer(this)
+    localVideoTrack.stop()
+    localVideoTrack.rtcTrack().dispose()
+    this.release()
+    peerConnectionFactory.dispose()
+    eglBase.release()
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+    dispose()
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
     PeerConnectionFactory.initialize(PeerConnectionFactory.InitializationOptions.builder(context).createInitializationOptions())
     eglBase = EglBase.create()
     peerConnectionFactory = PeerConnectionFactory.builder().createPeerConnectionFactory()
@@ -19,20 +39,7 @@ class VideoPreviewView(private val context: Context) {
     localVideoTrack = LocalVideoTrack.create(context, peerConnectionFactory, eglBase, VideoParameters.presetFHD169).also {
       it.start()
     }
-    view.init(eglBase.eglBaseContext, null)
-    localVideoTrack.addRenderer(view)
-  }
-
-  fun switchCamera(captureDeviceId: String) {
-    localVideoTrack.switchCamera(captureDeviceId)
-  }
-
-  fun dispose() {
-    localVideoTrack.removeRenderer(view)
-    localVideoTrack.stop()
-    localVideoTrack.rtcTrack().dispose()
-    view.release()
-    peerConnectionFactory.dispose()
-    eglBase.release()
+    init(eglBase.eglBaseContext, null)
+    localVideoTrack.addRenderer(this)
   }
 }

--- a/android/src/main/java/com/reactnativemembrane/VideoPreviewViewManager.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoPreviewViewManager.kt
@@ -1,20 +1,18 @@
+package com.reactnativemembrane
+
 import android.view.View
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.reactnativemembrane.VideoPreviewView
 import org.membraneframework.rtc.ui.VideoTextureViewRenderer
 import org.webrtc.RendererCommon
 
 class VideoPreviewViewManager : SimpleViewManager<View>() {
-  override fun getName() = "VideoPreviewView"
-
-  private val viewsWrappers = HashMap<VideoTextureViewRenderer, VideoPreviewView>()
+  override fun getName() = "com.reactnativemembrane.VideoPreviewView"
 
   override fun createViewInstance(reactContext: ThemedReactContext): View {
-    val wrapper = VideoPreviewView(reactContext)
-    wrapper.init()
-    viewsWrappers[wrapper.view] = wrapper
-    return wrapper.view
+    return VideoPreviewView(reactContext)
   }
 
   @ReactProp(name = "videoLayout")
@@ -29,17 +27,12 @@ class VideoPreviewViewManager : SimpleViewManager<View>() {
   }
 
   @ReactProp(name = "mirrorVideo")
-  fun setMirrorVideo(view: VideoTextureViewRenderer, mirror: Boolean) {
+  fun setMirrorVideo(view: VideoPreviewView, mirror: Boolean) {
     view.setMirror(mirror)
   }
 
   @ReactProp(name = "captureDeviceId")
-  fun setCaptureDeviceId(view: VideoTextureViewRenderer, captureDeviceId: String) {
-    viewsWrappers[view]?.switchCamera(captureDeviceId)
-  }
-
-  override fun onDropViewInstance(view: View) {
-    viewsWrappers[view]?.dispose()
-    viewsWrappers.remove(view)
+  fun setCaptureDeviceId(view: VideoPreviewView, captureDeviceId: String) {
+    view.switchCamera(captureDeviceId)
   }
 }

--- a/android/src/main/java/com/reactnativemembrane/VideoRendererView.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoRendererView.kt
@@ -7,17 +7,16 @@ import kotlinx.coroutines.launch
 import org.membraneframework.rtc.media.VideoTrack
 import org.membraneframework.rtc.ui.VideoTextureViewRenderer
 
-class VideoRendererWrapper(context: Context) {
-  var view: VideoTextureViewRenderer = VideoTextureViewRenderer(context)
+class VideoRendererView(context: Context): VideoTextureViewRenderer(context) {
   var isInitialized = false
   var activeVideoTrack: VideoTrack? = null
   var trackId: String? = null
 
-  fun setupTrack(videoTrack: VideoTrack) {
+  private fun setupTrack(videoTrack: VideoTrack) {
     if (activeVideoTrack == videoTrack) return
 
-    activeVideoTrack?.removeRenderer(view)
-    videoTrack.addRenderer(view)
+    activeVideoTrack?.removeRenderer(this)
+    videoTrack.addRenderer(this)
     activeVideoTrack = videoTrack
   }
 
@@ -27,7 +26,7 @@ class VideoRendererWrapper(context: Context) {
       val videoTrack = participant?.videoTracks?.get(trackId) ?: return@launch
       if(!isInitialized) {
         isInitialized = true
-        view.init(videoTrack.eglContext, null)
+        this@VideoRendererView.init(videoTrack.eglContext, null)
       }
       setupTrack(videoTrack)
     }
@@ -39,8 +38,7 @@ class VideoRendererWrapper(context: Context) {
   }
 
   fun dispose() {
-    activeVideoTrack?.removeRenderer(view)
-    view.release()
+    activeVideoTrack?.removeRenderer(this)
+    this.release()
   }
-
 }

--- a/android/src/main/java/com/reactnativemembrane/VideoRendererViewManager.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoRendererViewManager.kt
@@ -9,32 +9,32 @@ import org.webrtc.RendererCommon
 class VideoRendererViewManager : SimpleViewManager<View>() {
   override fun getName() = "VideoRendererView"
 
-  private val viewsWrappers = HashMap<VideoTextureViewRenderer, VideoRendererWrapper>();
+  private val views = ArrayList<VideoRendererView>()
 
   init {
     MembraneModule.onTracksUpdate = {
-      viewsWrappers.values.forEach { it.update() }
+      views.forEach { it.update() }
     }
   }
 
   override fun createViewInstance(reactContext: ThemedReactContext): View {
-    val wrapper = VideoRendererWrapper(reactContext)
-    viewsWrappers[wrapper.view] = wrapper
-    return wrapper.view
+    val view = VideoRendererView(reactContext)
+    views.add(view)
+    return view
   }
 
   override fun onDropViewInstance(view: View) {
-    viewsWrappers[view]?.dispose()
-    viewsWrappers.remove(view)
+    (view as VideoRendererView).dispose()
+    views.remove(view)
   }
 
   @ReactProp(name = "trackId")
-  fun setParticipantId(view: VideoTextureViewRenderer, trackId: String) {
-    viewsWrappers[view]?.init(trackId)
+  fun setParticipantId(view: VideoRendererView, trackId: String) {
+    view.init(trackId)
   }
 
   @ReactProp(name = "videoLayout")
-  fun setVideoLayout(view: VideoTextureViewRenderer, videoLayout: String) {
+  fun setVideoLayout(view: VideoRendererView, videoLayout: String) {
     val scalingType = when (videoLayout) {
       "FILL" -> RendererCommon.ScalingType.SCALE_ASPECT_FILL
       "FIT" -> RendererCommon.ScalingType.SCALE_ASPECT_FIT
@@ -45,7 +45,7 @@ class VideoRendererViewManager : SimpleViewManager<View>() {
   }
 
   @ReactProp(name = "mirrorVideo")
-  fun setMirrorVideo(view: VideoTextureViewRenderer, mirror: Boolean) {
+  fun setMirrorVideo(view: VideoRendererView, mirror: Boolean) {
     view.setMirror(mirror)
   }
 }

--- a/ios/VideoPreviewViewManager.swift
+++ b/ios/VideoPreviewViewManager.swift
@@ -25,12 +25,15 @@ class VideoPreviewView : UIView {
     addSubview(videoView!)
    
     localVideoTrack = LocalVideoTrack.create(videoParameters: VideoParameters.presetFHD169) as? LocalCameraVideoTrack
-    localVideoTrack?.start()
     videoView?.track = localVideoTrack
   }
   
-  override func removeFromSuperview() {
-    localVideoTrack?.stop()
+  override func willMove(toWindow newWindow: UIWindow?) {
+    if(newWindow == nil) {
+      localVideoTrack?.stop()
+    } else {
+      localVideoTrack?.start()
+    }
   }
   
   @available(*, unavailable)


### PR DESCRIPTION
It fixes the following bug on Android (and a similar one on iOS):
- go from preview screen to room screen
- go back
- preview is broken

Also helps to conserve resources.
I also refactored a little bit by the way.