### PR TITLE
Fix crash on iOS when killing backend in the middle of the call

### DIFF
--- a/ios/Membrane.swift
+++ b/ios/Membrane.swift
@@ -758,6 +758,8 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     if let connectResolve = connectResolve {
       connectResolve(nil)
     }
+    connectResolve = nil
+    connectReject = nil
   }
   
   func onJoinSuccess(peerID: String, peersInRoom: [Peer]) {


### PR DESCRIPTION
To reproduce:
- enter the call on ios
- kill the backend
- ios will crash