### PR TITLE
[MV-405] Fix deeplinking when app is in background

### DIFF
--- a/example/patches/@react-navigation+stack+6.3.16.patch
+++ b/example/patches/@react-navigation+stack+6.3.16.patch
@@ -11,7 +11,7 @@ index 77f48cd..593a3d3 100644
     * Function which returns a React Element to display custom image in header's back button.
     * It receives the `tintColor` in in the options object as an argument. object.
 diff --git a/node_modules/@react-navigation/stack/src/views/Stack/CardStack.tsx b/node_modules/@react-navigation/stack/src/views/Stack/CardStack.tsx
-index 4d4848f..beab2df 100755
+index 4d4848f..c19026a 100755
 --- a/node_modules/@react-navigation/stack/src/views/Stack/CardStack.tsx
 +++ b/node_modules/@react-navigation/stack/src/views/Stack/CardStack.tsx
 @@ -18,6 +18,8 @@ import {
@@ -41,7 +41,19 @@ index 4d4848f..beab2df 100755
          optionsForTransitionConfig.presentation === 'modal'
            ? ModalTransition
            : optionsForTransitionConfig.presentation === 'transparentModal'
-@@ -499,12 +499,18 @@ export default class CardStack extends React.Component<Props, State> {
+@@ -470,6 +470,11 @@ export default class CardStack extends React.Component<Props, State> {
+     return undefined;
+   };
+ 
++  private lastActivityStateForIndex: Record<
++    number,
++    number | Animated.AnimatedInterpolation<number>
++  > = {};
++
+   render() {
+     const {
+       insets,
+@@ -499,12 +504,18 @@ export default class CardStack extends React.Component<Props, State> {
  
      const isFloatHeaderAbsolute = this.state.scenes.slice(-2).some((scene) => {
        const options = scene.descriptor.options ?? {};
@@ -62,3 +74,38 @@ index 4d4848f..beab2df 100755
        ) {
          return true;
        }
+@@ -585,15 +596,23 @@ export default class CardStack extends React.Component<Props, State> {
+             // For the old implementation, it stays the same it was
+             let isScreenActive: Animated.AnimatedInterpolation | 2 | 1 | 0 = 1;
+ 
+-            if (index < self.length - activeScreensLimit - 1) {
++            const activeAfterTransition =
++              index >= self.length - activeScreensLimit;
++
++            if (
++              index < self.length - activeScreensLimit - 1 ||
++              (this.lastActivityStateForIndex[index] === STATE_INACTIVE &&
++                !activeAfterTransition)
++            ) {
+               // screen should be inactive because it is too deep in the stack
++              // or it was inactive before and it will still be inactive after the transition.
+               isScreenActive = STATE_INACTIVE;
+             } else {
+               const sceneForActivity = scenes[self.length - 1];
+               const outputValue =
+                 index === self.length - 1
+                   ? STATE_ON_TOP // the screen is on top after the transition
+-                  : index >= self.length - activeScreensLimit
++                  : activeAfterTransition
+                   ? STATE_TRANSITIONING_OR_BELOW_TOP // the screen should stay active after the transition, it is not on top but is in activeLimit
+                   : STATE_INACTIVE; // the screen should be active only during the transition, it is at the edge of activeLimit
+               isScreenActive = sceneForActivity
+@@ -605,6 +624,8 @@ export default class CardStack extends React.Component<Props, State> {
+                 : STATE_TRANSITIONING_OR_BELOW_TOP;
+             }
+ 
++            this.lastActivityStateForIndex[index] = isScreenActive;
++
+             const {
+               headerShown = true,
+               headerTransparent,

--- a/example/src/Navigation.tsx
+++ b/example/src/Navigation.tsx
@@ -8,10 +8,7 @@ import { JoinRoom } from '@screens/JoinRoom';
 import { LeaveRoomScreen } from '@screens/LeaveRoomScreen';
 import { Preview } from '@screens/Preview';
 import { Room } from '@screens/Room';
-import React, { useEffect } from 'react';
-import { Linking } from 'react-native';
-
-import { useVideoroomState } from './VideoroomContext';
+import React from 'react';
 
 const linking = {
   prefixes: [VIDEOROOM_URL],
@@ -44,17 +41,6 @@ const navTheme = {
 const Stack = createStackNavigator<RootStack>();
 
 export const Navigation = () => {
-  const { disconnect, videoroomState } = useVideoroomState();
-
-  useEffect(() => {
-    const listener = Linking.addEventListener('url', () => {
-      if (videoroomState === 'InMeeting') {
-        disconnect();
-      }
-      return () => listener.remove();
-    });
-  }, [disconnect, videoroomState]);
-
   return (
     <NavigationContainer linking={linking} theme={navTheme}>
       <Stack.Navigator

--- a/example/src/components/DiscardModal.tsx
+++ b/example/src/components/DiscardModal.tsx
@@ -15,12 +15,19 @@ type DiscardModalProps = {
   headline: string;
   body: string;
   buttonText: string;
+  handleBeforeRemoveEvent: (
+    e: GoBackAction,
+    setIsModalVisible: (isVisible: boolean) => void
+  ) => void;
+  onDiscard?: () => void;
 };
 
 export const DiscardModal = ({
   headline,
   body,
   buttonText,
+  handleBeforeRemoveEvent,
+  onDiscard = () => {},
 }: DiscardModalProps) => {
   const navigation = useNavigation();
   const { roomName, setRoomName, username, setUsername } = useVideoroomState();
@@ -29,20 +36,15 @@ export const DiscardModal = ({
 
   useFocusEffect(
     useCallback(() => {
-      const handleBeforeRemoveEvent = (e) => {
-        if (!roomName && !username) {
-          // If we don't have unsaved changes, then we don't need to do anything
-          return;
-        }
-        e.preventDefault();
+      const _handleBeforeRemoveEvent = (e) => {
+        handleBeforeRemoveEvent(e, setIsModalVisible);
         modalAction.current = e.data.action;
-        setIsModalVisible(true);
       };
 
-      navigation.addListener('beforeRemove', handleBeforeRemoveEvent);
+      navigation.addListener('beforeRemove', _handleBeforeRemoveEvent);
 
       return () =>
-        navigation.removeListener('beforeRemove', handleBeforeRemoveEvent);
+        navigation.removeListener('beforeRemove', _handleBeforeRemoveEvent);
     }, [navigation, roomName, username])
   );
 
@@ -60,6 +62,7 @@ export const DiscardModal = ({
           setRoomName('');
           setUsername('');
           navigation.dispatch(modalAction.current!);
+          onDiscard();
         }}
       >
         {buttonText}

--- a/example/src/screens/CreateRoom.tsx
+++ b/example/src/screens/CreateRoom.tsx
@@ -48,6 +48,15 @@ export const CreateRoom = ({ navigation, route }: Props) => {
     navigation.push('Preview', { title: 'New meeting' });
   };
 
+  const handleBeforeRemoveEvent = (e, setIsModalVisible) => {
+    if (!roomName && !username) {
+      // If we don't have unsaved changes, then we don't need to do anything
+      return;
+    }
+    e.preventDefault();
+    setIsModalVisible(true);
+  };
+
   return (
     <BackgroundAnimation>
       <SafeAreaView style={{ flex: 1 }} edges={['bottom']}>
@@ -69,6 +78,7 @@ export const CreateRoom = ({ navigation, route }: Props) => {
               headline="Discard meeting"
               body="Are you sure you want to discard creation of this meeting?"
               buttonText="Yes, discard meeting"
+              handleBeforeRemoveEvent={handleBeforeRemoveEvent}
             />
             <View style={styles.inner}>
               <View>

--- a/example/src/screens/JoinRoom.tsx
+++ b/example/src/screens/JoinRoom.tsx
@@ -63,6 +63,15 @@ export const JoinRoom = ({ navigation, route }: Props) => {
     navigation.push('Preview', { title: 'Join meeting' });
   };
 
+  const handleBeforeRemoveEvent = (e, setIsModalVisible) => {
+    if (!roomName && !username) {
+      // If we don't have unsaved changes, then we don't need to do anything
+      return;
+    }
+    e.preventDefault();
+    setIsModalVisible(true);
+  };
+
   return (
     <BackgroundAnimation>
       <SafeAreaView style={{ flex: 1 }} edges={['bottom']}>
@@ -84,6 +93,7 @@ export const JoinRoom = ({ navigation, route }: Props) => {
               headline="Cancel joining meeting"
               body="Are you sure you want to cancel joining to this meeting?"
               buttonText="Yes, don't join"
+              handleBeforeRemoveEvent={handleBeforeRemoveEvent}
             />
             <View style={styles.inner}>
               <View>

--- a/example/src/screens/LeaveRoomScreen.tsx
+++ b/example/src/screens/LeaveRoomScreen.tsx
@@ -25,6 +25,11 @@ export const LeaveRoomScreen = ({ navigation }: Props) => {
     }
   }, [connectAndJoinRoom]);
 
+  const onMainScreenPress = useCallback(() => {
+    navigation.navigate('InitialScreen');
+    goToMainScreen();
+  }, []);
+
   return (
     <BackgroundAnimation>
       <View style={styles.content}>
@@ -40,7 +45,7 @@ export const LeaveRoomScreen = ({ navigation }: Props) => {
         </Typo>
 
         <View style={styles.mainButton}>
-          <StandardButton onPress={goToMainScreen}>Main page</StandardButton>
+          <StandardButton onPress={onMainScreenPress}>Main page</StandardButton>
         </View>
         <View style={styles.rejoinButton}>
           <StandardButton type="secondary" onPress={rejoinMeeting}>

--- a/example/src/screens/Preview.tsx
+++ b/example/src/screens/Preview.tsx
@@ -62,6 +62,7 @@ export const Preview = ({ navigation, route }: Props) => {
   const onConnectPress = useCallback(async () => {
     try {
       await connectAndJoinRoom();
+      navigation.navigate('Room');
     } catch (err) {
       showNotification('Error connecting to server', 'error');
       Sentry.captureException(err);


### PR DESCRIPTION
The bug can be reproduced by trying to click a link when app was in Room or Leave screen. The JoinRoom screen was not mounted at all so there was no way to navigate to it.
Now all screens are in the same stack, not conditionally rendered with this fix: https://github.com/react-navigation/react-navigation/pull/11315

Pro tip for fast testing on android: `adb shell am start -W -a android.intent.action.VIEW -d "https://videoroom.membrane.work/room/Membrane%20Frontend%20Stand-up" com.membrane.reactnativemembrane` simulates a deeplink click
on iOS there is a similar command