### PR TITLE
[MV-433] Fix Android app not always switching to bluetooth headphones

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -176,5 +176,5 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
   implementation 'com.github.jellyfish-dev:membrane-webrtc-android:4.4.1'
-  implementation 'com.twilio:audioswitch:1.1.7'
+  api 'com.github.davidliu:audioswitch:8edf84ee46cdbc84c2b7725aa8f8d66363e19876'
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
   package="com.membrane.reactnativemembrane">
 
   <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
   <application
     android:name=".MainApplication"
     android:allowBackup="false"

--- a/example/src/shared/handlePermissions.ts
+++ b/example/src/shared/handlePermissions.ts
@@ -10,7 +10,6 @@ export const handlePermissions = async (callback: Function) => {
     const granted = await PermissionsAndroid.requestMultiple([
       PermissionsAndroid.PERMISSIONS.CAMERA,
       PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
-      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
     ]);
     if (
       granted[PermissionsAndroid.PERMISSIONS.CAMERA] ===


### PR DESCRIPTION
`BLUETOOTH_CONNECT` permission is no longer necessary.
Please test especially the scenario on the first run of the application. The app should automatically switch to bluetooth headphones if they're connected. Otherwise it should be switched to speakersphone.