### PR TITLE
[RTC-239] Refactor for Jellyfish client

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -175,6 +175,6 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
-  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:4.5.0'
+  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:c9a84a5280365a2874911e936349d7cfbdbef1b1'
   api 'com.github.davidliu:audioswitch:8edf84ee46cdbc84c2b7725aa8f8d66363e19876'
 }

--- a/android/src/main/java/com/reactnativemembrane/MembraneModule.kt
+++ b/android/src/main/java/com/reactnativemembrane/MembraneModule.kt
@@ -122,7 +122,7 @@ class MembraneModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun create(url: String, roomName: String, createOptions: ReadableMap, promise: Promise) {
+  fun create(url: String, createOptions: ReadableMap, promise: Promise) {
     val videoQuality = createOptions.getString("quality")
     var flipVideo = true
     if (createOptions.hasKey("flipVideo"))

--- a/example/ios/MembraneExample.xcodeproj/project.pbxproj
+++ b/example/ios/MembraneExample.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 				INFOPLIST_FILE = MembraneExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 0.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -520,6 +521,7 @@
 				INFOPLIST_FILE = MembraneExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 0.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,6 +31,8 @@ target 'MembraneExample' do
 
   pod 'react-native-membrane', :path => '../..'
 
+  pod 'MembraneRTC', :git => 'https://github.com/jellyfish-dev/membrane-webrtc-ios', :branch => 'graszka22/socket-refactor'
+
   # Enables Flipper.
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
@@ -48,5 +50,5 @@ target 'MembraneExample' do
 end
 
 target 'ScreenBroadcast' do
-  pod 'MembraneRTC/Broadcast'
+  pod 'MembraneRTC/Broadcast', :git => 'https://github.com/jellyfish-dev/membrane-webrtc-ios', :branch => 'graszka22/socket-refactor'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -516,7 +516,8 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
-  - MembraneRTC/Broadcast
+  - MembraneRTC (from `https://github.com/jellyfish-dev/membrane-webrtc-ios`, branch `graszka22/socket-refactor`)
+  - MembraneRTC/Broadcast (from `https://github.com/jellyfish-dev/membrane-webrtc-ios`, branch `graszka22/socket-refactor`)
   - OpenSSL-Universal (= 1.1.1100)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -574,7 +575,6 @@ SPEC REPOS:
     - fmt
     - libevent
     - Logging
-    - MembraneRTC
     - OpenSSL-Universal
     - OrderedObjectSet
     - PromisesObjC
@@ -619,6 +619,9 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes/hermes-engine.podspec"
+  MembraneRTC:
+    :branch: graszka22/socket-refactor
+    :git: https://github.com/jellyfish-dev/membrane-webrtc-ios
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -691,6 +694,11 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@sentry/react-native"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
+
+CHECKOUT OPTIONS:
+  MembraneRTC:
+    :commit: 5532e9a99224bb8455b9034779e4f3807d5fda52
+    :git: https://github.com/jellyfish-dev/membrane-webrtc-ios
 
 SPEC CHECKSUMS:
   AssociatedValues: 33dfc4f4d0ec2f1177a2558e176364e2ac849cd1
@@ -774,6 +782,6 @@ SPEC CHECKSUMS:
   Yoga: d6133108734e69e8c0becc6ba587294b94829687
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: e38aa9e9f463a3b3260c491618d93c4c965da37d
+PODFILE CHECKSUM: 54f2feb52315c3c82c2f1ec76f6009c6cf26a482
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/example/src/VideoroomContext.tsx
+++ b/example/src/VideoroomContext.tsx
@@ -110,7 +110,6 @@ const VideoroomContextProvider = (props) => {
     Sentry.setExtra('user name', trimmedUserName);
 
     await connect(getServerUrl(), trimmedRoomName, {
-      userMetadata: { displayName: trimmedUserName },
       socketChannelParams: {
         isSimulcastOn: true,
       },
@@ -133,7 +132,7 @@ const VideoroomContextProvider = (props) => {
       audioTrackEnabled: isMicrophoneOn,
       captureDeviceId: currentCamera?.id,
     });
-    await joinRoom();
+    await joinRoom({ displayName: trimmedUserName });
     setVideoroomState('InMeeting');
   }, [roomName, username, isCameraOn, isMicrophoneOn, currentCamera]);
 

--- a/ios/Membrane.m
+++ b/ios/Membrane.m
@@ -3,13 +3,12 @@
 
 @interface RCT_EXTERN_MODULE(Membrane, RCTEventEmitter <RCTBridgeModule>)
 
-RCT_EXTERN_METHOD(connect:(NSString)url
-                  withRoomName:(NSString)roomName
+RCT_EXTERN_METHOD(create:(NSString)url
                   withConnectionOptions:(NSDictionary)connectionOptions
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(join:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(join:(NSDictionary)peerMetadata withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(disconnect:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getParticipants:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(toggleCamera:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
@@ -36,5 +35,6 @@ RCT_EXTERN_METHOD(getStatistics:(RCTPromiseResolveBlock)resolve withRejecter:(RC
 RCT_EXTERN_METHOD(selectAudioSessionMode:(NSString)sessionMode withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(showAudioRoutePicker:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(startAudioSwitcher:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(receiveMediaEvent:(NSString)data withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 @end
 

--- a/ios/Membrane.swift
+++ b/ios/Membrane.swift
@@ -35,7 +35,7 @@ public extension AnyJson {
   func toDict() -> [String: Any] {
     var res: [String: Any] = [:]
     self.keys.forEach { key in
-        res[key] = self[key]
+      res[key] = self[key]
     }
     return res
   }
@@ -105,7 +105,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   }
   
   @objc static override func requiresMainQueueSetup() -> Bool {
-      return false
+    return false
   }
   
   private func getSimulcastConfigFrom(options: NSDictionary, reject: RCTPromiseRejectBlock) -> SimulcastConfig? {
@@ -177,8 +177,8 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     return trackEncoding
   }
   
-    @objc(create:withConnectionOptions:withResolver:withRejecter:)
-    func create(url: String, connectionOptions: NSDictionary, resolve:@escaping RCTPromiseResolveBlock,reject:@escaping RCTPromiseRejectBlock) -> Void {
+  @objc(create:withConnectionOptions:withResolver:withRejecter:)
+  func create(url: String, connectionOptions: NSDictionary, resolve:@escaping RCTPromiseResolveBlock,reject:@escaping RCTPromiseRejectBlock) -> Void {
     let videoQuality = connectionOptions["quality"] as? String ?? ""
     let flipVideo = connectionOptions["flipVideo"] as? Bool ?? true
     let videoTrackMetadata = (connectionOptions["videoTrackMetadata"] as? NSDictionary)?.toMetadata() ?? Metadata()
@@ -186,74 +186,74 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     self.isMicEnabled = connectionOptions["audioTrackEnabled"] as? Bool ?? true
     self.isCameraEnabled = connectionOptions["videoTrackEnabled"] as? Bool ?? true
     let captureDeviceId = connectionOptions["captureDeviceId"] as? String
-      
+    
     guard let videoSimulcastConfig = getSimulcastConfigFrom(options: connectionOptions, reject: reject) else {
       return
     }
     self.videoSimulcastConfig = videoSimulcastConfig
     let videoBandwidthLimit = getBandwidthLimitFrom(options: connectionOptions)
-        
+    
     let room = MembraneRTC.create(delegate: self)
-      self.room = room
-      
-      let preset: VideoParameters = {
-        switch videoQuality {
-        case "QVGA169":
-          return VideoParameters.presetQVGA169
-        case "VGA169":
-          return VideoParameters.presetVGA169
-        case "VQHD169":
-          return VideoParameters.presetQHD169
-        case "HD169":
-          return VideoParameters.presetHD169
-        case "FHD169":
-          return VideoParameters.presetFHD169
-        case "QVGA43":
-          return VideoParameters.presetQVGA43
-        case "VGA43":
-          return VideoParameters.presetVGA43
-        case "VQHD43":
-          return VideoParameters.presetQHD43
-        case "HD43":
-          return VideoParameters.presetHD43
-        case "FHD43":
-          return VideoParameters.presetFHD43
-        default:
-          return VideoParameters.presetVGA169
-        }
-      }()
-      let videoParameters = VideoParameters(
-        dimensions: flipVideo ? preset.dimensions.flip() : preset.dimensions,
-        maxBandwidth: videoBandwidthLimit,
-        simulcastConfig: self.videoSimulcastConfig
-      )
-      
-      let localParticipantId = UUID().uuidString
-      self.localParticipantId = localParticipantId
-      
-      localVideoTrack = room.createVideoTrack(videoParameters: videoParameters, metadata: videoTrackMetadata, captureDeviceId: captureDeviceId)
-      localVideoTrack?.setEnabled(isCameraEnabled)
-      localAudioTrack = room.createAudioTrack(metadata: audioTrackMetadata)
-      localAudioTrack?.setEnabled(isMicEnabled)
-      setAudioSessionMode()
-      
-      var localParticipant = Participant(
-        id: localParticipantId,
-        metadata: localUserMetadata)
-      
-      if let localVideoTrack = localVideoTrack {
-        localParticipant.videoTracks = [localVideoTrack.trackId(): localVideoTrack]
-        localParticipant.tracksMetadata[localVideoTrack.trackId()] = videoTrackMetadata
+    self.room = room
+    
+    let preset: VideoParameters = {
+      switch videoQuality {
+      case "QVGA169":
+        return VideoParameters.presetQVGA169
+      case "VGA169":
+        return VideoParameters.presetVGA169
+      case "VQHD169":
+        return VideoParameters.presetQHD169
+      case "HD169":
+        return VideoParameters.presetHD169
+      case "FHD169":
+        return VideoParameters.presetFHD169
+      case "QVGA43":
+        return VideoParameters.presetQVGA43
+      case "VGA43":
+        return VideoParameters.presetVGA43
+      case "VQHD43":
+        return VideoParameters.presetQHD43
+      case "HD43":
+        return VideoParameters.presetHD43
+      case "FHD43":
+        return VideoParameters.presetFHD43
+      default:
+        return VideoParameters.presetVGA169
       }
-      
-      if let localAudioTrack = localAudioTrack {
-        localParticipant.audioTracks = [localAudioTrack.trackId(): localAudioTrack]
-        localParticipant.tracksMetadata[localAudioTrack.trackId()] = audioTrackMetadata
-      }
-      
-      MembraneRoom.sharedInstance.participants[localParticipantId] = localParticipant
-      
-      resolve(nil)
+    }()
+    let videoParameters = VideoParameters(
+      dimensions: flipVideo ? preset.dimensions.flip() : preset.dimensions,
+      maxBandwidth: videoBandwidthLimit,
+      simulcastConfig: self.videoSimulcastConfig
+    )
+    
+    let localParticipantId = UUID().uuidString
+    self.localParticipantId = localParticipantId
+    
+    localVideoTrack = room.createVideoTrack(videoParameters: videoParameters, metadata: videoTrackMetadata, captureDeviceId: captureDeviceId)
+    localVideoTrack?.setEnabled(isCameraEnabled)
+    localAudioTrack = room.createAudioTrack(metadata: audioTrackMetadata)
+    localAudioTrack?.setEnabled(isMicEnabled)
+    setAudioSessionMode()
+    
+    var localParticipant = Participant(
+      id: localParticipantId,
+      metadata: localUserMetadata)
+    
+    if let localVideoTrack = localVideoTrack {
+      localParticipant.videoTracks = [localVideoTrack.trackId(): localVideoTrack]
+      localParticipant.tracksMetadata[localVideoTrack.trackId()] = videoTrackMetadata
+    }
+    
+    if let localAudioTrack = localAudioTrack {
+      localParticipant.audioTracks = [localAudioTrack.trackId(): localAudioTrack]
+      localParticipant.tracksMetadata[localAudioTrack.trackId()] = audioTrackMetadata
+    }
+    
+    MembraneRoom.sharedInstance.participants[localParticipantId] = localParticipant
+    
+    resolve(nil)
   }
   
   @objc(join:withResolver:withRejecter:)
@@ -293,8 +293,8 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     }
     guard let screencastExtensionBundleId = screencastExtensionBundleId,
           let appGroupName = appGroupName else {
-            return
-          }
+      return
+    }
     
     // if screensharing is enabled it must be closed by the Broadcast Extension, not by our application
     // the only thing we can do is to display stop recording button, which we already do
@@ -307,23 +307,23 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     }
     if(!ensureConnected(reject)) { return }
     guard let room = room else {
-        return
+      return
     }
     
     let preset: VideoParameters = {
       switch(screencastOptions["quality"] as? String) {
-        case "VGA":
-          return VideoParameters.presetScreenShareVGA
-        case "HD5":
-          return VideoParameters.presetScreenShareHD5
-        case "HD15":
-          return VideoParameters.presetScreenShareHD15
-        case "FHD15":
-          return VideoParameters.presetScreenShareFHD15
-        case "FHD30":
-          return VideoParameters.presetScreenShareFHD30
-        default:
-          return VideoParameters.presetScreenShareHD15
+      case "VGA":
+        return VideoParameters.presetScreenShareVGA
+      case "HD5":
+        return VideoParameters.presetScreenShareHD5
+      case "HD15":
+        return VideoParameters.presetScreenShareHD15
+      case "FHD15":
+        return VideoParameters.presetScreenShareFHD15
+      case "FHD30":
+        return VideoParameters.presetScreenShareFHD30
+      default:
+        return VideoParameters.presetScreenShareHD15
       }
     }()
     guard let screenshareSimulcastConfig = getSimulcastConfigFrom(options: screencastOptions, reject: reject) else {
@@ -340,7 +340,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     
     let screencastMetadata = (screencastOptions["screencastMetadata"] as? NSDictionary)?.toMetadata() ?? Metadata()
     
-      self.localScreencastTrack = room.createScreencastTrack(appGroup: appGroupName, videoParameters: videoParameters, metadata: screencastMetadata, onStart: { [weak self] screencastTrack in
+    self.localScreencastTrack = room.createScreencastTrack(appGroup: appGroupName, videoParameters: videoParameters, metadata: screencastMetadata, onStart: { [weak self] screencastTrack in
       guard let self = self else {
         DispatchQueue.main.async {
           RPSystemBroadcastPickerView.show(for: screencastExtensionBundleId)
@@ -349,12 +349,12 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       }
       
       guard let localParticipantId = self.localParticipantId, let screencastTrackId = self.localScreencastTrack?.trackId() else {
-         return
+        return
       }
-        
+      
       MembraneRoom.sharedInstance.participants[localParticipantId]?.videoTracks[screencastTrackId] = screencastTrack
       MembraneRoom.sharedInstance.participants[localParticipantId]?.tracksMetadata[screencastTrackId] = screencastMetadata
-        
+      
       self.isScreensharingEnabled = true
       self.emitEvent(name: "IsScreencastOn", data: true)
       self.emitParticipants()
@@ -406,7 +406,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
         "metadata": p.tracksMetadata[trackId]?.toDict() ?? [:],
         "vadStatus": tracksContexts[trackId]?.vadStatus.rawValue as Any,
       ]}
-        
+      
       return [
         "id": p.id,
         "metadata": p.metadata.toDict(),
@@ -415,7 +415,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       ]
     }]
   }
-    
+  
   func getSimulcastConfigAsRNMap(simulcastConfig: SimulcastConfig) -> [String: Any] {
     return [
       "enabled": simulcastConfig.enabled,
@@ -458,9 +458,9 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   func flipCamera(resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
     if(!ensureVideoTrack(reject)) { return }
     guard let cameraTrack = localVideoTrack as? LocalCameraVideoTrack else {
-        return
+      return
     }
-
+    
     cameraTrack.switchCamera()
     resolve(nil)
   }
@@ -490,13 +490,13 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     }
     resolve(rnArray)
   }
-    
+  
   @objc(updatePeerMetadata:withResolver:withRejecter:)
   func updatePeerMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
-        if(!ensureConnected(reject)) { return }
-        room?.updatePeerMetadata(peerMetadata: metadata.toMetadata())
-        resolve(nil)
-    }
+    if(!ensureConnected(reject)) { return }
+    room?.updatePeerMetadata(peerMetadata: metadata.toMetadata())
+    resolve(nil)
+  }
   
   func updateTrackMetadata(trackId: String, metadata:NSDictionary) {
     guard let room = room, let peerId = localParticipantId else {
@@ -507,39 +507,39 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     MembraneRoom.sharedInstance.participants[peerId]?.tracksMetadata[trackId] = metadata.toMetadata()
     emitParticipants()
   }
-    
-    @objc(updateVideoTrackMetadata:withResolver:withRejecter:)
-    func updateVideoTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
-        if(!ensureVideoTrack(reject)) { return }
-        guard let trackId = localVideoTrack?.trackId() else {
-            return
-        }
-
-        updateTrackMetadata(trackId: trackId, metadata: metadata)
-        resolve(nil)
+  
+  @objc(updateVideoTrackMetadata:withResolver:withRejecter:)
+  func updateVideoTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
+    if(!ensureVideoTrack(reject)) { return }
+    guard let trackId = localVideoTrack?.trackId() else {
+      return
     }
     
-    @objc(updateAudioTrackMetadata:withResolver:withRejecter:)
-    func updateAudioTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
-      if(!ensureAudioTrack(reject)) { return }
-        guard let trackId = localAudioTrack?.trackId() else {
-            return
-        }
-
-      updateTrackMetadata(trackId: trackId, metadata: metadata)
-        resolve(nil)
+    updateTrackMetadata(trackId: trackId, metadata: metadata)
+    resolve(nil)
+  }
+  
+  @objc(updateAudioTrackMetadata:withResolver:withRejecter:)
+  func updateAudioTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
+    if(!ensureAudioTrack(reject)) { return }
+    guard let trackId = localAudioTrack?.trackId() else {
+      return
     }
     
-    @objc(updateScreencastTrackMetadata:withResolver:withRejecter:)
-    func updateScreencastTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
-      if(!ensureScreencastTrack(reject)) { return }
-        guard let trackId = localScreencastTrack?.trackId() else {
-            return
-        }
-
-      updateTrackMetadata(trackId: trackId, metadata: metadata)
-        resolve(nil)
+    updateTrackMetadata(trackId: trackId, metadata: metadata)
+    resolve(nil)
+  }
+  
+  @objc(updateScreencastTrackMetadata:withResolver:withRejecter:)
+  func updateScreencastTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) -> Void {
+    if(!ensureScreencastTrack(reject)) { return }
+    guard let trackId = localScreencastTrack?.trackId() else {
+      return
     }
+    
+    updateTrackMetadata(trackId: trackId, metadata: metadata)
+    resolve(nil)
+  }
   
   private func toggleTrackEncoding(encoding: TrackEncoding, trackId: String, simulcastConfig: SimulcastConfig) -> SimulcastConfig? {
     guard let room = room else {
@@ -644,78 +644,78 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     }
     room.setTrackBandwidth(trackId: trackId, bandwidth: BandwidthLimit(truncating: bandwidth))
   }
-
+  
   @objc(changeWebRTCLoggingSeverity:withResolver:withRejecter:)
   func changeWebRTCLoggingSeverity(severity: NSString, resolve:RCTPromiseResolveBlock, reject:@escaping RCTPromiseRejectBlock) {
     switch severity {
     case "verbose":
-       room?.changeWebRTCLoggingSeverity(severity: .verbose)
+      room?.changeWebRTCLoggingSeverity(severity: .verbose)
     case "info":
-       room?.changeWebRTCLoggingSeverity(severity: .info)
+      room?.changeWebRTCLoggingSeverity(severity: .info)
     case "warning":
-       room?.changeWebRTCLoggingSeverity(severity: .warning)
+      room?.changeWebRTCLoggingSeverity(severity: .warning)
     case "error":
-       room?.changeWebRTCLoggingSeverity(severity: .error)
+      room?.changeWebRTCLoggingSeverity(severity: .error)
     case "none":
-       room?.changeWebRTCLoggingSeverity(severity: .none)
+      room?.changeWebRTCLoggingSeverity(severity: .none)
     default:
       reject("E_INVALID_SEVERITY_LEVEL", "Severity with name=\(severity) not found", nil)
       return
     }
     resolve(nil)
   }
-    
+  
   private func getMapFromStatsObject(obj: RTCInboundStats) -> [String: Any] {
-      var res: [String:Any] = [:]
-      res["kind"] = obj.kind
-      res["jitter"] = obj.jitter
-      res["packetsLost"] = obj.packetsLost
-      res["packetsReceived"] = obj.packetsReceived
-      res["bytesReceived"] = obj.bytesReceived
-      res["framesReceived"] = obj.framesReceived
-      res["frameWidth"] = obj.frameWidth
-      res["frameHeight"] = obj.frameHeight
-      res["framesPerSecond"] = obj.framesPerSecond
-      res["framesDropped"] = obj.framesDropped
-      
-      return res
-  }
-
-  private func getMapFromStatsObject(obj: RTCOutboundStats) -> [String: Any] {
-      var innerMap: [String: Double] = [:]
-
-      innerMap["bandwidth"] = obj.qualityLimitationDurations?.bandwidth ?? 0.0
-      innerMap["cpu"] = obj.qualityLimitationDurations?.cpu ?? 0.0
-      innerMap["none"] = obj.qualityLimitationDurations?.none ?? 0.0
-      innerMap["other"] = obj.qualityLimitationDurations?.other ?? 0.0
-      
-      var res: [String: Any] = [:]
-      res["kind"] = obj.kind
-      res["rid"] = obj.rid
-      res["bytesSent"] = obj.bytesSent
-      res["targetBitrate"] = obj.targetBitrate
-      res["packetsSent"] = obj.packetsSent
-      res["framesEncoded"] = obj.framesEncoded
-      res["framesPerSecond"] = obj.framesPerSecond
-      res["frameWidth"] = obj.frameWidth
-      res["frameHeight"] = obj.frameHeight
-      res["qualityLimitationDurations"] = innerMap
-      
-      return res
-  }
-
-  private func statsToRNMap(stats: [String: RTCStats]?) -> [String: Any] {
-      var res: [String: Any] = [:]
-      stats?.forEach{ pair in
-          if let val = pair.value as? RTCOutboundStats {
-              res[pair.key] = getMapFromStatsObject(obj: val)
-          } else {
-              res[pair.key] = getMapFromStatsObject(obj: pair.value as! RTCInboundStats)
-          }
-      }
-      return res
-  }
+    var res: [String:Any] = [:]
+    res["kind"] = obj.kind
+    res["jitter"] = obj.jitter
+    res["packetsLost"] = obj.packetsLost
+    res["packetsReceived"] = obj.packetsReceived
+    res["bytesReceived"] = obj.bytesReceived
+    res["framesReceived"] = obj.framesReceived
+    res["frameWidth"] = obj.frameWidth
+    res["frameHeight"] = obj.frameHeight
+    res["framesPerSecond"] = obj.framesPerSecond
+    res["framesDropped"] = obj.framesDropped
     
+    return res
+  }
+  
+  private func getMapFromStatsObject(obj: RTCOutboundStats) -> [String: Any] {
+    var innerMap: [String: Double] = [:]
+    
+    innerMap["bandwidth"] = obj.qualityLimitationDurations?.bandwidth ?? 0.0
+    innerMap["cpu"] = obj.qualityLimitationDurations?.cpu ?? 0.0
+    innerMap["none"] = obj.qualityLimitationDurations?.none ?? 0.0
+    innerMap["other"] = obj.qualityLimitationDurations?.other ?? 0.0
+    
+    var res: [String: Any] = [:]
+    res["kind"] = obj.kind
+    res["rid"] = obj.rid
+    res["bytesSent"] = obj.bytesSent
+    res["targetBitrate"] = obj.targetBitrate
+    res["packetsSent"] = obj.packetsSent
+    res["framesEncoded"] = obj.framesEncoded
+    res["framesPerSecond"] = obj.framesPerSecond
+    res["frameWidth"] = obj.frameWidth
+    res["frameHeight"] = obj.frameHeight
+    res["qualityLimitationDurations"] = innerMap
+    
+    return res
+  }
+  
+  private func statsToRNMap(stats: [String: RTCStats]?) -> [String: Any] {
+    var res: [String: Any] = [:]
+    stats?.forEach{ pair in
+      if let val = pair.value as? RTCOutboundStats {
+        res[pair.key] = getMapFromStatsObject(obj: val)
+      } else {
+        res[pair.key] = getMapFromStatsObject(obj: pair.value as! RTCInboundStats)
+      }
+    }
+    return res
+  }
+  
   @objc(getStatistics:withRejecter:)
   func getStatistics(resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
     let mapped = statsToRNMap(stats:room?.getStats())
@@ -726,7 +726,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     guard let localAudioTrack = localAudioTrack else {
       return
     }
-
+    
     switch self.audioSessionMode {
     case AVAudioSession.Mode.videoChat:
       localAudioTrack.setVideoChatMode()

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@react-native-community/eslint-config": "^3.0.3",
     "@release-it/bumper": "^4.0.0",
     "@types/jest": "^26.0.0",
+    "@types/phoenix": "^1.5.6",
     "@types/promise-fs": "^2.1.2",
     "@types/react": "^16.9.19",
     "@types/react-native": "0.67.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "useTabs": false
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.1.5"
+    "@expo/config-plugins": "^4.1.5",
+    "phoenix": "^1.7.2"
   },
   "lint-staged": {
     "*.(js|ts|tsx)": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -352,11 +352,6 @@ export function useMembraneServer() {
   const webrtcChannel = useRef<any>(null);
 
   useEffect(() => {
-    const eventListener = eventEmitter.addListener('MembraneError', setError);
-    return () => eventListener.remove();
-  }, []);
-
-  useEffect(() => {
     const eventListener = eventEmitter.addListener(
       'SendMediaEvent',
       sendMediaEvent
@@ -437,7 +432,7 @@ export function useMembraneServer() {
         socket.current = _socket;
         webrtcChannel.current = _webrtcChannel;
 
-        await Membrane.create(url, roomName, connectionOptions);
+        await Membrane.create(url, connectionOptions);
 
         await new Promise<void>((resolve, reject) => {
           _webrtcChannel

--- a/yarn.lock
+++ b/yarn.lock
@@ -10432,6 +10432,11 @@ phin@^2.9.1:
   resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
   integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
 
+phoenix@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/phoenix/-/phoenix-1.7.2.tgz#7bee9d5dd6dc3a8b30b94bb5e058375a4063a931"
+  integrity sha512-jwWDOsUNEQZkLNSwzfLJ6AMFUkyZ+ILU+NkBBtoAK020QPpV/dYEQHGMQoFScj89MFjJlLdkE1W97i8S+4FdGg==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,6 +3107,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/phoenix@^1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.5.6.tgz#fca4e7315c7f743bf6f04805588b7261b11818db"
+  integrity sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA==
+
 "@types/prettier@^1.19.0":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"


### PR DESCRIPTION
- create and manage socket on the JS side
- in Jellyfish we'll create a different `connect` function with another socket and use that socket for backend communication. We'll use the `receiveMediaEvent` function and `onSendMediaEvent` callback (or event in case of RN) to communicate with WebRTC part
- join function now takes `peerMetadata`, it's no longer in `ConnectionOptions`

Question: should we finally create a context and a provider for this lib and manage the socket etc there, in one place? It will be problematic if someone calls `useMembraneServer` twice.