### PR TITLE
Fix camera on/off switch in Room screen

### DIFF
--- a/android/src/main/java/com/reactnativemembrane/VideoPreviewView.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoPreviewView.kt
@@ -8,40 +8,41 @@ import org.membraneframework.rtc.media.VideoParameters
 import org.webrtc.EglBase
 
 class VideoPreviewView(private val context: Context): VideoTextureViewRenderer(context) {
-  private lateinit var localVideoTrack: LocalVideoTrack
-  private lateinit var eglBase: EglBase
-  private lateinit var peerConnectionFactory: PeerConnectionFactory
+  private var localVideoTrack: LocalVideoTrack? = null
+  private var eglBase: EglBase? = null
+  private var peerConnectionFactory: PeerConnectionFactory? = null
   private var isInitialized: Boolean = false
 
-  init {
-    initialize()
-  }
+  private var captureDeviceId: String? = null
 
   private fun initialize() {
     if(isInitialized) return
     isInitialized = true
     PeerConnectionFactory.initialize(PeerConnectionFactory.InitializationOptions.builder(context).createInitializationOptions())
-    eglBase = EglBase.create()
-    peerConnectionFactory = PeerConnectionFactory.builder().createPeerConnectionFactory()
+    val eglBase = EglBase.create()
+    this.eglBase = eglBase
+    val peerConnectionFactory = PeerConnectionFactory.builder().createPeerConnectionFactory()
+    this.peerConnectionFactory = peerConnectionFactory
 
     localVideoTrack = LocalVideoTrack.create(context, peerConnectionFactory, eglBase, VideoParameters.presetFHD169).also {
       it.start()
     }
     init(eglBase.eglBaseContext, null)
-    localVideoTrack.addRenderer(this)
+    localVideoTrack?.addRenderer(this)
   }
 
   fun switchCamera(captureDeviceId: String) {
-    localVideoTrack.switchCamera(captureDeviceId)
+    this.captureDeviceId = captureDeviceId
+    localVideoTrack?.switchCamera(captureDeviceId)
   }
 
   private fun dispose() {
-    localVideoTrack.removeRenderer(this)
-    localVideoTrack.stop()
-    localVideoTrack.rtcTrack().dispose()
+    localVideoTrack?.removeRenderer(this)
+    localVideoTrack?.stop()
+    localVideoTrack?.rtcTrack()?.dispose()
     this.release()
-    peerConnectionFactory.dispose()
-    eglBase.release()
+    peerConnectionFactory?.dispose()
+    eglBase?.release()
     isInitialized = false
   }
 

--- a/ios/VideoPreviewViewManager.swift
+++ b/ios/VideoPreviewViewManager.swift
@@ -23,16 +23,15 @@ class VideoPreviewView : UIView {
     videoView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     videoView?.clipsToBounds = true
     addSubview(videoView!)
-   
-    localVideoTrack = LocalVideoTrack.create(videoParameters: VideoParameters.presetFHD169) as? LocalCameraVideoTrack
-    videoView?.track = localVideoTrack
   }
   
   override func willMove(toWindow newWindow: UIWindow?) {
     if(newWindow == nil) {
       localVideoTrack?.stop()
     } else {
+      localVideoTrack = LocalVideoTrack.create(videoParameters: VideoParameters.presetFHD169) as? LocalCameraVideoTrack
       localVideoTrack?.start()
+      videoView?.track = localVideoTrack
     }
   }
   


### PR DESCRIPTION
This is pretty tricky bug :D It was caused by this commit: https://github.com/jellyfish-dev/react-native-membrane-webrtc/pull/93/files
Here is what happens when we go to the room screen and toggle the camera:
- in preview screen everything is ok, you can turn the camera on/off, no problem
- you go to the room screen
- the preview screen is in the stack but it's detached by the navigation
- the preview view is detached too, the local track is disposed all ok
- the room screen is attached and the local track is initialized again
- then we turn the camera off, the local track is disabled
- hey, remember that preview screen? it's not attached but it's still somewhere in the memory and it just updated and replaced the preview view with a placeholder - it's nothing bad (yet!)
- then we turn the camera back on
- the preview screen is updated again and wants to create a preview view, the `initialize` function is called even though it's not attached to window and we can't have two local camera tracks so weird stuff happens

Solution? Now we initialize the track only when window is attached and it seems to be fixed now. 
