### PR TITLE
[MV-461] Fix crashes when many peers leave room at once

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -175,6 +175,6 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
-  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:graszka22~MV-461-SNAPSHOT'
+  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:4.5.2'
   api 'com.github.davidliu:audioswitch:8edf84ee46cdbc84c2b7725aa8f8d66363e19876'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -175,6 +175,6 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
-  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:4.5.1'
+  implementation 'com.github.jellyfish-dev:membrane-webrtc-android:graszka22~MV-461-SNAPSHOT'
   api 'com.github.davidliu:audioswitch:8edf84ee46cdbc84c2b7725aa8f8d66363e19876'
 }


### PR DESCRIPTION
The crashes are generally caused by modyfying `participants` map in different threads (native modules thread, main thread and webrtc threads). Now I'm executing everything on the main thread so there shouldn't be any problem. This shouldn't have any big impacts on performance since those operations are quick and without i/o.
Related PR: https://github.com/jellyfish-dev/membrane-webrtc-android/pull/42

