### PR TITLE
[MV-480] remove speaking information from screenshare tracks

### DIFF
--- a/example/src/components/FocusedParticipant.tsx
+++ b/example/src/components/FocusedParticipant.tsx
@@ -26,14 +26,17 @@ export const FocusedParticipant = ({
 
   const isParticipantSpeaking =
     focusedParticipant.participant.tracks.find((t) => t.type === 'Audio')
-      ?.vadStatus === 'speech' &&
-    focusedTrack?.metadata.type !== 'screensharing';
+      ?.vadStatus === 'speech';
+
+  const isScreenshare = focusedTrack?.metadata.type !== 'screensharing';
 
   return (
     <View
       style={[
         styles.focusedParticipantContainer,
-        isParticipantSpeaking ? styles.activeSpeakerContainer : {},
+        isParticipantSpeaking && isScreenshare === false
+          ? styles.activeSpeakerContainer
+          : {},
       ]}
     >
       {isLocalScreenshareTrack ? (
@@ -46,7 +49,7 @@ export const FocusedParticipant = ({
           focused
         />
       )}
-      {isParticipantSpeaking ? (
+      {isParticipantSpeaking && isScreenshare === false ? (
         <View style={styles.activeSpeakerBorder} />
       ) : null}
     </View>

--- a/example/src/components/FocusedParticipant.tsx
+++ b/example/src/components/FocusedParticipant.tsx
@@ -26,7 +26,8 @@ export const FocusedParticipant = ({
 
   const isParticipantSpeaking =
     focusedParticipant.participant.tracks.find((t) => t.type === 'Audio')
-      ?.vadStatus === 'speech';
+      ?.vadStatus === 'speech' &&
+    focusedTrack?.metadata.type !== 'screensharing';
 
   return (
     <View

--- a/example/src/components/FocusedParticipant.tsx
+++ b/example/src/components/FocusedParticipant.tsx
@@ -27,7 +27,7 @@ export const FocusedParticipant = ({
   const isParticipantSpeaking =
     focusedParticipant.participant.tracks.find((t) => t.type === 'Audio')
       ?.vadStatus === 'speech' &&
-    focusedTrack?.metadata.type === 'screensharing';
+    focusedTrack?.metadata.type !== 'screensharing';
 
   return (
     <View

--- a/example/src/components/FocusedParticipant.tsx
+++ b/example/src/components/FocusedParticipant.tsx
@@ -28,7 +28,7 @@ export const FocusedParticipant = ({
     focusedParticipant.participant.tracks.find((t) => t.type === 'Audio')
       ?.vadStatus === 'speech';
 
-  const isScreenshare = focusedTrack?.metadata.type !== 'screensharing';
+  const isScreenshare = focusedTrack?.metadata.type === 'screensharing';
 
   return (
     <View

--- a/example/src/components/FocusedParticipant.tsx
+++ b/example/src/components/FocusedParticipant.tsx
@@ -26,17 +26,14 @@ export const FocusedParticipant = ({
 
   const isParticipantSpeaking =
     focusedParticipant.participant.tracks.find((t) => t.type === 'Audio')
-      ?.vadStatus === 'speech';
-
-  const isScreenshare = focusedTrack?.metadata.type === 'screensharing';
+      ?.vadStatus === 'speech' &&
+    focusedTrack?.metadata.type === 'screensharing';
 
   return (
     <View
       style={[
         styles.focusedParticipantContainer,
-        isParticipantSpeaking && isScreenshare === false
-          ? styles.activeSpeakerContainer
-          : {},
+        isParticipantSpeaking ? styles.activeSpeakerContainer : {},
       ]}
     >
       {isLocalScreenshareTrack ? (
@@ -49,7 +46,7 @@ export const FocusedParticipant = ({
           focused
         />
       )}
-      {isParticipantSpeaking && isScreenshare === false ? (
+      {isParticipantSpeaking ? (
         <View style={styles.activeSpeakerBorder} />
       ) : null}
     </View>

--- a/example/src/components/Participants.tsx
+++ b/example/src/components/Participants.tsx
@@ -55,6 +55,13 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
     );
   };
 
+  const isVideoTrackScreenshare = (participant: Participant) => {
+    return (
+      participant.participant.tracks.find((t) => t.id === participant.trackId)
+        ?.metadata.type !== 'screensharing'
+    );
+  };
+
   return (
     <View style={styles.participantsContainer}>
       <View
@@ -86,7 +93,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
                 onPinButtonPressed={onPress}
                 tileSmall={participants.length > FLEX_BRAKPOINT || width < 350}
               />
-              {isParticipantSpeaking(p) ? (
+              {isParticipantSpeaking(p) && isVideoTrackScreenshare(p) ? (
                 <View style={styles.activeSpeakerBorder} />
               ) : null}
             </View>

--- a/example/src/components/Participants.tsx
+++ b/example/src/components/Participants.tsx
@@ -51,12 +51,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
   const isParticipantSpeaking = (participant: Participant) => {
     return (
       participant.participant.tracks.find((t) => t.type === 'Audio')
-        ?.vadStatus === 'speech'
-    );
-  };
-
-  const isVideoTrackScreenshare = (participant: Participant) => {
-    return (
+        ?.vadStatus === 'speech' &&
       participant.participant.tracks.find((t) => t.id === participant.trackId)
         ?.metadata.type === 'screensharing'
     );
@@ -82,7 +77,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
               key={p.participant.id + p.trackId}
               style={[
                 getStylesForParticipants(),
-                isParticipantSpeaking(p) && isVideoTrackScreenshare(p) === false
+                isParticipantSpeaking(p)
                   ? styles.shownActiveParticipantBorder
                   : styles.shownParticipantBorder,
               ]}
@@ -93,8 +88,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
                 onPinButtonPressed={onPress}
                 tileSmall={participants.length > FLEX_BRAKPOINT || width < 350}
               />
-              {isParticipantSpeaking(p) &&
-              isVideoTrackScreenshare(p) === false ? (
+              {isParticipantSpeaking(p) ? (
                 <View style={styles.activeSpeakerBorder} />
               ) : null}
             </View>

--- a/example/src/components/Participants.tsx
+++ b/example/src/components/Participants.tsx
@@ -58,7 +58,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
   const isVideoTrackScreenshare = (participant: Participant) => {
     return (
       participant.participant.tracks.find((t) => t.id === participant.trackId)
-        ?.metadata.type !== 'screensharing'
+        ?.metadata.type === 'screensharing'
     );
   };
 
@@ -82,7 +82,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
               key={p.participant.id + p.trackId}
               style={[
                 getStylesForParticipants(),
-                isParticipantSpeaking(p)
+                isParticipantSpeaking(p) && isVideoTrackScreenshare(p) === false
                   ? styles.shownActiveParticipantBorder
                   : styles.shownParticipantBorder,
               ]}
@@ -93,7 +93,8 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
                 onPinButtonPressed={onPress}
                 tileSmall={participants.length > FLEX_BRAKPOINT || width < 350}
               />
-              {isParticipantSpeaking(p) && isVideoTrackScreenshare(p) ? (
+              {isParticipantSpeaking(p) &&
+              isVideoTrackScreenshare(p) === false ? (
                 <View style={styles.activeSpeakerBorder} />
               ) : null}
             </View>

--- a/example/src/components/Participants.tsx
+++ b/example/src/components/Participants.tsx
@@ -53,7 +53,7 @@ export const Participants = ({ participants, onPress }: ParticipantsProp) => {
       participant.participant.tracks.find((t) => t.type === 'Audio')
         ?.vadStatus === 'speech' &&
       participant.participant.tracks.find((t) => t.id === participant.trackId)
-        ?.metadata.type === 'screensharing'
+        ?.metadata.type !== 'screensharing'
     );
   };
 


### PR DESCRIPTION
Please check scenario: Remote participants stars screensharing and then talking. No vad status information should be displayed on the screenshare video track (both when focused and not)