### PR TITLE
Fix memory leak

### DIFF
--- a/example/src/shared/participantsTracksManager.ts
+++ b/example/src/shared/participantsTracksManager.ts
@@ -4,7 +4,7 @@ import { getNumberOfCurrentlyVisiblePlaces } from '@utils';
 import { useRef, useEffect } from 'react';
 
 export type ParticipantWithTrack = {
-  participant: Membrane.Participant;
+  participant: Membrane.Endpoint;
   trackId?: string;
   timeAdded: number;
 };

--- a/ios/VideoRendererViewManager.swift
+++ b/ios/VideoRendererViewManager.swift
@@ -24,8 +24,8 @@ class VideoRendererView : UIView {
     videoView?.clipsToBounds = true
     addSubview(videoView!)
     cancellableEndpoints = MembraneRoom.sharedInstance.$endpoints
-      .sink { _ in
-        self.updateVideoTrack()
+      .sink { [weak self] _ in
+        self?.updateVideoTrack()
       }
   }
   


### PR DESCRIPTION
To fix completely: https://github.com/jellyfish-dev/membrane-webrtc-ios/pull/43 
To test:
- make a lot of remote tracks (or display one track many times)
- turn them on/off several times
- the app memory in xcode profiler goes up, it should stay on approximately the same level