### PR TITLE
[EX-29] Screencast crash in mobile app

### DIFF
--- a/android/src/main/java/com/reactnativemembrane/MembraneModule.kt
+++ b/android/src/main/java/com/reactnativemembrane/MembraneModule.kt
@@ -248,6 +248,9 @@ class MembraneModule(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun disconnect(promise: Promise) {
     CoroutineScope(Dispatchers.Main).launch {
+      if (isScreenCastOn) {
+        stopScreencast()
+      }
       room?.disconnect()
       room = null
       endpoints.clear()
@@ -638,6 +641,7 @@ class MembraneModule(reactContext: ReactApplicationContext) :
       emitEndpoints()
     }
     screencastPromise?.resolve(isScreenCastOn)
+    emitEvent("IsScreencastOn", isScreenCastOn)
   }
 
   private fun stopScreencast() {
@@ -652,6 +656,7 @@ class MembraneModule(reactContext: ReactApplicationContext) :
     emitEndpoints()
     screencastPromise?.resolve(isScreenCastOn)
     screencastPromise = null
+    emitEvent("IsScreencastOn", isScreenCastOn)
   }
 
   private fun emitEvent(eventName: String, data: Any?) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -459,7 +459,7 @@ PODS:
   - Sentry/HybridSDK (8.3.3):
     - SentryPrivate (= 8.3.3)
   - SentryPrivate (8.3.3)
-  - SocketRocket (0.6.0)
+  - SocketRocket (0.6.1)
   - SwiftAlgorithms (1.0.0)
   - SwiftLogJellyfish (1.5.2)
   - SwiftPhoenixClient (4.0.0):
@@ -752,7 +752,7 @@ SPEC CHECKSUMS:
   RNSentry: 8363f1eff1c685a502e15080b5e2f447969897c5
   Sentry: 8ffc397d98fe58d693e73959b26ed0eaee55646a
   SentryPrivate: bf776a47a131648f5023097215987b40fbd47025
-  SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
+  SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SwiftAlgorithms: 38dda4731d19027fdeee1125f973111bf3386b53
   SwiftLogJellyfish: 6207ec91ef3913d303ac797b73298248ee360eb0
   SwiftPhoenixClient: 4e36f35d00e43d11881c255bd60c20efc0f39c91

--- a/ios/Membrane.swift
+++ b/ios/Membrane.swift
@@ -248,6 +248,15 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   
   @objc(disconnect:withRejecter:)
   func disconnect(resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) -> Void {
+    guard isScreensharingEnabled == false else {
+      DispatchQueue.main.async {
+        RPSystemBroadcastPickerView.show(for: screencastExtensionBundleId)
+      }
+      self.emitEvent(name: "IsScreencastOn", data: false)
+      resolve(nil)
+      return
+    }
+
     room?.remove(delegate: self)
     room?.disconnect()
     room = nil

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -705,14 +705,10 @@ export function useScreencast() {
   );
 
   useEffect(() => {
-    if (Platform.OS === 'ios') {
-      const eventListener = eventEmitter.addListener(
-        'IsScreencastOn',
-        (event) => setIsScreencastOn(event)
-      );
-      return () => eventListener.remove();
-    }
-    return () => {};
+    const eventListener = eventEmitter.addListener('IsScreencastOn', (event) =>
+      setIsScreencastOn(event)
+    );
+    return () => eventListener.remove();
   }, []);
 
   /**
@@ -720,10 +716,7 @@ export function useScreencast() {
    */
   const toggleScreencast = useCallback(
     async (screencastOptions: Partial<ScreencastOptions> = {}) => {
-      const state = await Membrane.toggleScreencast(screencastOptions);
-      if (Platform.OS === 'android') {
-        setIsScreencastOn(state);
-      }
+      await Membrane.toggleScreencast(screencastOptions);
       screencastSimulcastConfig =
         screencastOptions.simulcastConfig || defaultSimulcastConfig();
       setSimulcastConfig(screencastSimulcastConfig);


### PR DESCRIPTION
After this changes are applied screencast is always stopped before leaving the call, which fixes the bug.